### PR TITLE
want to ignore change events due to being referenced, even though they haven't been edited in a long time

### DIFF
--- a/config.go
+++ b/config.go
@@ -24,12 +24,13 @@ import (
 type Config struct {
 	RequiredVersion string `yaml:"required_version,omitempty"`
 
-	Webhook      string                    `yaml:"webhook,omitempty"`
-	Credentials  *CredentialsBackendConfig `yaml:"credentials,omitempty"`
-	Expiration   time.Duration             `yaml:"expiration,omitempty"`
-	Storage      *StorageConfig            `yaml:"storage,omitempty"`
-	Notification *NotificationConfig       `yaml:"notification,omitempty"`
-	Drives       []*DriveConfig            `yaml:"drives,omitempty"`
+	Webhook            string                    `yaml:"webhook,omitempty"`
+	Credentials        *CredentialsBackendConfig `yaml:"credentials,omitempty"`
+	Expiration         time.Duration             `yaml:"expiration,omitempty"`
+	Storage            *StorageConfig            `yaml:"storage,omitempty"`
+	Notification       *NotificationConfig       `yaml:"notification,omitempty"`
+	Drives             []*DriveConfig            `yaml:"drives,omitempty"`
+	WithinModifiedTime *time.Duration            `yaml:"within_modified_time,omitempty"`
 
 	versionConstraints gv.Constraints `yaml:"version_constraints,omitempty"`
 }

--- a/webhook.go
+++ b/webhook.go
@@ -75,7 +75,7 @@ func (app *App) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			coalesce(channelID, "-"),
 			coalesce(resourceID, "-"),
 		)
-		if err := app.notification.SendChanges(ctx, item, changes); err != nil {
+		if err := app.SendNotification(ctx, item, changes); err != nil {
 			logx.Printf(ctx, "[error] send changes failed channel_id:%s resource_id:%s err:%s",
 				coalesce(channelID, "-"),
 				coalesce(resourceID, "-"),


### PR DESCRIPTION
I want to ignore change events due to being referenced, even though they haven't been edited in a long time

The following settings were added for this purpose

`within_modified_time`

```yaml
required_version: ">=0.0.0"

webhook: "{{ env `HTTP_TUNNEL_URL` }}"
expiration: 168h
within_modified_time: 30m

storage:
  type: File
  data_file: data/storage.gob

notification:
  type: File
  event_file: data/events.json

drives:
  - drive_id: __default__
```

When this setting is made, the system ignores change times that are more than 30 minutes past the current time.