### PR TITLE
Feature/fix example

### DIFF
--- a/handler.go
+++ b/handler.go
@@ -170,7 +170,7 @@ func (app *App) handleWebhook(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if len(changes) > 0 {
-		slog.DebugContext(ctx, "Sending changes", "channel_id", coalesce(channelID, "-"), "resource_id", coalesce(resourceID, "-"))
+		slog.InfoContext(ctx, "Sending changes", "channel_id", coalesce(channelID, "-"), "resource_id", coalesce(resourceID, "-"))
 		if err := app.SendNotification(ctx, item, changes); err != nil {
 			slog.ErrorContext(ctx, "Failed to send changes", "channel_id", coalesce(channelID, "-"), "resource_id", coalesce(resourceID, "-"), "error", err)
 			w.WriteHeader(http.StatusInternalServerError)
@@ -178,7 +178,7 @@ func (app *App) handleWebhook(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	} else {
-		slog.DebugContext(ctx, "No changes", "channel_id", coalesce(channelID, "-"), "resource_id", coalesce(resourceID, "-"))
+		slog.InfoContext(ctx, "No changes", "channel_id", coalesce(channelID, "-"), "resource_id", coalesce(resourceID, "-"))
 	}
 	w.WriteHeader(http.StatusOK)
 	io.WriteString(w, http.StatusText(http.StatusOK))

--- a/lambda/example.tf
+++ b/lambda/example.tf
@@ -54,6 +54,13 @@ resource "aws_iam_role_policy" "main" {
         Effect   = "Allow"
         Resource = "*",
       },
+      {
+        Action = [
+          "events:PutEvents",
+        ],
+        Effect   = "Allow"
+        Resource = "*",
+      },
     ]
   })
 }


### PR DESCRIPTION
This pull request includes changes to the logging level in the `handleWebhook` function and updates to the IAM role policy in the Terraform configuration. 

Changes to logging level:

* [`handler.go`](diffhunk://#diff-0eb779b9e49d8e44b0f36923fdb8d87d5ee024f886eefc45deec4ec88380a087L173-R181): Updated the logging level from `Debug` to `Info` for messages indicating whether changes are being sent or not.

Updates to IAM role policy:

* [`lambda/example.tf`](diffhunk://#diff-d459708441692776e5da84f6e0a3b19674088c9c438348cb03528a0da052015bR57-R63): Added a new policy action allowing `events:PutEvents` to the IAM role policy.